### PR TITLE
add tabulate to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-python-bugzilla
 jira
+python-bugzilla
 python-dateutil
+tabulate


### PR DESCRIPTION
To avoid this issue:

  $ ./network_bugs_overview
  Traceback (most recent call last):
  File "/home/vagrant/dev/douglas_bugzilla/tmp/bz-query/./network_bugs_overview", line 6, in <module>
    from tabulate import tabulate
  ModuleNotFoundError: No module named 'tabulate'

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>