### PR TITLE
Count recently assigned bugs

### DIFF
--- a/network_bugs_overview
+++ b/network_bugs_overview
@@ -2,6 +2,7 @@
 import argparse
 import collections
 from datetime import date, datetime, timedelta
+from dateutil.parser import parse
 import sys
 from tabulate import tabulate
 import time
@@ -88,6 +89,7 @@ CNCC_COMPONENT = "networking / cloud-network-config-controller"
 ESCALATIONS_COMPONENT = "networking/sdn"
 TEAM_COMPONENTS = (GENERIC_COMPONENT, SDN_COMPONENT, OVN_COMPONENT, CNCC_COMPONENT,
                    INGRESS_FW_COMPONENT, METAL_LB_COMPONENT)
+ASSIGN_WINDOW_DAYS = 21  # 3 weeks in a sprint
 
 
 def init_developers_dict():
@@ -105,6 +107,7 @@ def init_developers_dict():
                     "bugs_in_new": 0,
                     "bugs_in_assigned": 0,
                     "bugs_in_post": 0,
+                    "recently_assigned": 0,
                     "bugs_urls": [],
                 },
             )
@@ -112,6 +115,18 @@ def init_developers_dict():
         ]
     )
     return developers
+
+
+def retrieve_jira_bugs_for_given_dev(dev_name):
+    clients = init_clients(bz=False, jira_=True)
+    query = init_jira_query_for_one_assignee(dev_name)
+    bugs = run_jira_query(clients[JIRA_KEY], query)
+    return bugs
+
+
+def count_recently_assigned_bugs(dev_name):
+    bugs = retrieve_jira_bugs_for_given_dev(dev_name)
+    return sum(was_jira_bug_recently_assigned(b) for b in bugs)
 
 
 def init_queries(clients, bz=True, jira_bugs=True, jira_escalations=False):
@@ -174,9 +189,9 @@ def init_bz_query(bzapi):
     return query
 
 
-def init_jira_query_for_bugs():
+def init_jira_query_for_bugs(open_only=True):
     project = "OCPBUGS"
-    return init_jira_query(project, TEAM_COMPONENTS)
+    return init_jira_query(project, TEAM_COMPONENTS, open_only)
 
 
 def init_jira_query_for_escalations():
@@ -184,14 +199,39 @@ def init_jira_query_for_escalations():
     return init_jira_query(project, ESCALATIONS_COMPONENT)
 
 
-def init_jira_query(project, components):
+def get_username_and_usermail_from_assignee(assignee):
+    # always return user,user@redhat.com regardless of whether
+    # assignee is a username or a usermail
+    # Useful for jira, where the usermail is most often, but not always,
+    # what appears as assignee for a bug.
+    mail_domain = '@redhat.com'
+    if assignee.endswith(mail_domain):
+        usermail = assignee
+        username = assignee[:-len(mail_domain)]
+    else:
+        usermail = assignee + mail_domain
+        username = assignee
+    return username, usermail
+
+
+def init_jira_query_for_one_assignee(assignee):
+    # include both username and username@redhat.com
+    assignee_tpl = 'assignee in ("{}", "{}") and '
+    username, usermail = get_username_and_usermail_from_assignee(assignee)
+    query = assignee_tpl.format(username, usermail) + init_jira_query_for_bugs(open_only=False)
+    return query
+
+
+def init_jira_query(project, components, open_only=True):
     if isinstance(components, str):
         components = (components,)  # make it a tuple
-    #   new, assigned, on_dev, post, on_qa, verified, modified, release_pending, closed
-    query_fmt = (
-        "project={} and component in ({}) and "
-        'status in ("NEW", "ASSIGNED", "POST", "ON_DEV")'
-    )
+
+    query_fmt = "project={} and component in ({})"
+    if open_only:
+        # Possible states: new, assigned, on_dev, post, on_qa, verified,
+        # modified, release_pending, closed
+        query_fmt += ' and status in ("NEW", "ASSIGNED", "POST", "ON_DEV")'
+
     component_substr = ", ".join(('"{}"'.format(c) for c in components))
     bugs_query = query_fmt.format(project, component_substr)
     return bugs_query
@@ -202,8 +242,8 @@ def time_query(func):
         t_start = time.time()
         bugs = func(bz_api, query_str)
         t_end = time.time()
-        print("- Found {} bugs with the query: {}".format(len(bugs), query_str))
-        print("  Query processing time: {:.1f}s".format(t_end - t_start))
+        print("- Found {} bugs in {:.1f}s with the query: {}".format(
+            len(bugs), t_end - t_start, query_str))
         return bugs
 
     return wrapper
@@ -227,14 +267,17 @@ def run_jira_query(jira_api, query):
     max_attempts = 100
     for i in range(max_attempts):
         try:
-            res = jira_api.search_issues(query, maxResults=False)
-        except Exception as e:
-            print("[attempt {}] Error running JIRA query {}, error: {}".format(i, query, e))
+            res = jira_api.search_issues(query, maxResults=False, expand="changelog")
+        except:
+            # print("[attempt {}] Error running JIRA query {}, error: {}".format(i, query, e))
+            sys.stdout.write(".")
+            sys.stdout.flush()
             time.sleep(0.05)
             if i == max_attempts-1:
-                sys.exit("Could not query JIRA server successfully after {} attempts".format(max_attempts))
+                sys.exit("Failed to query JIRA server {} times. Query: {}".format(
+                    max_attempts, query))
         else:
-            print("JIRA query was successful at attempt={}".format(i))
+            print("JIRA query successful at attempt={}".format(i))
             break
     return res
 
@@ -317,17 +360,65 @@ def process_bz_bugs(bugs, developers):
     return developers, stale_bugs
 
 
-def process_jira_bugs(bugs, developers):
+def was_jira_bug_recently_assigned(bug):
+    # Evaluate whether the bug
+    # Example of the changelog field for a jira bug:
+    # {'id': '41700442',
+    #  'author': {'self': 'https://issues.redhat.com/rest/api/2/user?username=rravaiol%40redhat.com',
+    #   'name': 'rravaiol@redhat.com',
+    #   'key': 'JIRAUSER165708',
+    #   'emailAddress': 'rravaiol@redhat.com',
+    #   'displayName': 'Riccardo Ravaioli',
+    #   'active': True,
+    #   'timeZone': 'UTC'},
+    #  'created': '2023-01-06T14:36:45.317+0000',
+    #  'items': [{'field': 'assignee',
+    #    'fieldtype': 'jira',
+    #    'from': 'bbennett',
+    #    'fromString': 'Ben Bennett',
+    #    'to': 'JIRAUSER163232',
+    #    'toString': 'Jaime Caamaño Ruiz'}]},
+    # skip automatically-generated backports
+    if "prow bot" in bug.get_field('creator').displayName.lower():
+        return False
+
+    try:
+        # take all changelogs that modified the assignee and evaluate the latest
+        assignee_changes = sorted(
+            [change for change in bug.changelog.histories
+             for item in change.items
+             if item.field == 'assignee'],
+            key=lambda change: parse(change.created))  # sort by change timestamp
+
+        if assignee_changes:
+            latest_assign = assignee_changes[-1].created
+        else:
+            # if there are no assign changelogs, assume that the ticket was created
+            # already with the current assignee and consider the creation date
+            # as the assigning date
+            latest_assign = bug.get_field("created")
+
+        days_difference = (datetime.now() - parse(latest_assign).replace(tzinfo=None)).days
+        return days_difference <= ASSIGN_WINDOW_DAYS
+
+    except Exception as ex:
+        print("could not evaluate changelog for {}: {}".format(bug, ex))
+
+    return False
+
+
+def process_jira_bugs(bugs, developers, quick=False):
     # bugs that have been in new state for more than 30 days (arbitary time window)
     stale_bugs = {}
     for bug in bugs:
         assignee = bug.get_field("assignee").name if bug.get_field("assignee") else None
         if not assignee:
             continue
+        assignee_user, assignee_mail = get_username_and_usermail_from_assignee(assignee)
         # values for status: new, assigned, on_dev, post, on_qa, verified, modified,
         # release_pending, closed
         status = bug.get_field("status").name.lower()
-        bug_id = str(bug.id)
+        bug_id = str(bug.key)
         creation_time = bug.get_field("created")
         summary = bug.get_field("summary")
         bug_key = str(bug.key)
@@ -355,26 +446,20 @@ def process_jira_bugs(bugs, developers):
 
         # an assignee in jira bugs is very often a developer's official email address, but
         # it might also be just a username. On BZ aliases are the primary choice.
-        if assignee not in developers:
+        if assignee_mail not in developers:
             if "@" in assignee:
-                # skip this bug
+                # skip this bug, assignee is not in the team
                 continue
             else:
-                # try with full email address if assignee is not in that form already
-                tmp_assignee = "{}@redhat.com".format(assignee)
-                if tmp_assignee in developers:
-                    assignee = tmp_assignee
+                # try with known aliases
+                tmp_assignee = RH_DEVELOPERS_ALIASES.get(assignee_user)
+                if tmp_assignee:
+                    assignee_user, assignee_mail = get_username_and_usermail_from_assignee(tmp_assignee)
                 else:
-                    # try with known aliases
-                    tmp_assignee = RH_DEVELOPERS_ALIASES.get(assignee)
-                    if tmp_assignee:
-                        assignee = tmp_assignee
-                    else:
-                        # no valid assignee found, skip this bug
-                        continue
-
+                    # no valid assignee found, skip this bug
+                    continue
         if status == "new":
-            developers[assignee]["bugs_in_new"] += 1
+            developers[assignee_mail]["bugs_in_new"] += 1
             # Bugs in NEW state for more than 30 days
             creation_time_obj = parser.parse(creation_time)
             if (creation_time_obj + timedelta(days=STALE_THRESHOLD)).replace(
@@ -392,30 +477,37 @@ def process_jira_bugs(bugs, developers):
 
         elif status in ("assigned", "on_dev"):
             # not sure how the new values coexist with the old ones...
-            developers[assignee]["bugs_in_assigned"] += 1
+            developers[assignee_mail]["bugs_in_assigned"] += 1
 
         elif status == "post":
-            developers[assignee]["bugs_in_post"] += 1
+            developers[assignee_mail]["bugs_in_post"] += 1
 
-        developers[assignee]["number_of_bugs"] += 1
+        developers[assignee_mail]["number_of_bugs"] += 1
 
         if OVN_COMPONENT in components:
-            developers[assignee]["number_of_ovnk_bugs"] += 1
+            developers[assignee_mail]["number_of_ovnk_bugs"] += 1
         elif SDN_COMPONENT in components:
-            developers[assignee]["number_of_osdn_bugs"] += 1
+            developers[assignee_mail]["number_of_osdn_bugs"] += 1
         elif ESCALATIONS_COMPONENT in components:
-            developers[assignee]["number_of_escalations"] += 1
+            developers[assignee_mail]["number_of_escalations"] += 1
         else:
-            developers[assignee]["number_of_other_bugs"] += 1
+            developers[assignee_mail]["number_of_other_bugs"] += 1
 
-        developers[assignee]["bugs_urls"].append(url)
-        developers[assignee]["points"] += (
+        developers[assignee_mail]["bugs_urls"].append(url)
+        developers[assignee_mail]["points"] += (
             SEVERITY_WEIGHTS[severity] + PRIORITY_WEIGHTS[priority]
         )
+
+    if not quick:
+        # for each developer, issue a new query and count the number of
+        # recently assigned bugs (open or closed)
+        for dev in developers:
+            developers[dev]["recently_assigned"] = count_recently_assigned_bugs(dev)
+
     return developers, stale_bugs
 
 
-def process_bugs(bugs_dict, developers):
+def process_bugs(bugs_dict, developers, quick=False):
     stale_bugs = {}
     if BZ_BUGS in bugs_dict:
         bugs = bugs_dict[BZ_BUGS]["bugs"]
@@ -424,18 +516,18 @@ def process_bugs(bugs_dict, developers):
 
     if JIRA_BUGS in bugs_dict:
         bugs = bugs_dict[JIRA_BUGS]["bugs"]
-        developers, stale_bugs_jira = process_jira_bugs(bugs, developers)
+        developers, stale_bugs_jira = process_jira_bugs(bugs, developers, quick)
         stale_bugs.update(stale_bugs_jira)
 
     if JIRA_ESCALATIONS in bugs_dict:
         bugs = bugs_dict[JIRA_ESCALATIONS]["bugs"]
-        developers, stale_bugs_jira = process_jira_bugs(bugs, developers)
+        developers, stale_bugs_jira = process_jira_bugs(bugs, developers, quick=True)
         stale_bugs.update(stale_bugs_jira)
 
     return developers, stale_bugs
 
 
-def print_results(developers, stale_bugs, print_stale_bugs=False):
+def print_results(developers, stale_bugs, print_stale_bugs=False, quick=False):
     # Sorting the list by points field
     ordered_by_points = collections.OrderedDict(
         sorted(developers.items(), key=lambda x: x[1]["points"])
@@ -490,6 +582,9 @@ def print_results(developers, stale_bugs, print_stale_bugs=False):
         print("  NEW:         {}".format(v["bugs_in_new"]))
         print("  ASSIGNED:    {}".format(v["bugs_in_assigned"]))
         print("  POST:        {}".format(v["bugs_in_post"]))
+        if not quick:
+            print("  Assigned <= {} days: {}".format(
+                ASSIGN_WINDOW_DAYS, v["recently_assigned"]))
         print("  Bug URLs:    {}".format(v["bugs_urls"]))
         print("")
 
@@ -516,8 +611,7 @@ def print_results(developers, stale_bugs, print_stale_bugs=False):
     )
 
 
-def print_summary_table(developers
-                        ):
+def print_summary_table(developers, quick=False):
     # Sorting the list by points field
     ordered_by_points = collections.OrderedDict(
         sorted(developers.items(), key=lambda x: x[1]["points"])
@@ -533,16 +627,20 @@ def print_summary_table(developers
         + colors.END
     )
     # Rank list starts with 1, which means developer least overloaded at the moment
-    headers = ("#", "Developer", "Points", "Bugs", "NEW", "ASSIGNED", "POST")
+    headers = ["#", "Developer", "Points", "Bugs", "NEW", "ASSIGNED", "POST"]
+    if not quick:
+        headers.append("Assigned\n <=21 days")
     lines = []
     for rank, (k, v) in enumerate(ordered_by_points.items()):
-        new_line = (rank+1,
+        new_line = [rank+1,
                     k,
                     v["points"],
                     v["number_of_bugs"],
                     v["bugs_in_new"],
                     v["bugs_in_assigned"],
-                    v["bugs_in_post"])
+                    v["bugs_in_post"]]
+        if not quick:
+            new_line.append(v["recently_assigned"])
         lines.append(new_line)
     print(tabulate(lines, headers=headers))
 
@@ -573,6 +671,11 @@ def parse_input_args():
     )
 
     parser.add_argument(
+        "-q", "--quick",
+        help="Skip assign analysis and get results more quickly",
+        action="store_true"
+    )
+    parser.add_argument(
         "--old-bugs",
         help=(
             "Print a list of bugs that have been in the new"
@@ -600,7 +703,8 @@ def parse_input_args():
         "jira_bugs": jira_bugs,
         "jira_escalations": jira_escalations,
         "old-bugs": bool(args.old_bugs),
-        "verbose": bool(args.verbose)
+        "verbose": bool(args.verbose),
+        "quick": bool(args.quick)
     }
 
     return params
@@ -614,11 +718,15 @@ def main():
         jira_bugs=params.get("jira_bugs"),
         jira_escalations=params.get("jira_escalations"),
     )
-    developers, stale_bugs = process_bugs(bugs_dict, developers)
+    developers, stale_bugs = process_bugs(bugs_dict, developers, params.get("quick"))
     if params.get("verbose"):
-        print_results(developers, stale_bugs, print_stale_bugs=params.get("old-bugs"))
+        print_results(developers,
+                      stale_bugs,
+                      print_stale_bugs=params.get("old-bugs"),
+                      quick=params.get("quick"))
+        print_summary_table(developers, params.get("quick"))
     else:
-        print_summary_table(developers)
+        print_summary_table(developers, params.get("quick"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In order to improve balance across team members when assigning new bugs, show also for each developer the number of bugs assigned in the past 21 days (moving window, symbolically equivalent to one sprint). Backports generated by Prow bot are excluded from the count.

The recently-assigned count requires n new queries to the JIRA server, with n = # of developers in the team. In order to skip this costly evaluation, the new command line argument "-q" or "--quick" should be used.

Improved output when a query to JIRA server fails: now a single dot is printed instead of the full error, which we wouldn't be able to fix on our side anyway.

Signed-off-by: Riccardo Ravaioli <rravaiol@redhat.com>